### PR TITLE
Config readability

### DIFF
--- a/copying.md
+++ b/copying.md
@@ -11,6 +11,7 @@ _the openage authors_ are:
 | Jonas Jelten                | TheJJ                       | jj@sft.mx                        |
 | Michael Enßlin              | mic_e                       | michael@ensslin.cc               |
 | Markus Otto                 | zuntrax                     | otto@fs.tum.de                   |
+| Janosch Kindl               | kindl                       | janoschkindl+openage@gmail.com   |
 
 If you're a first-time commiter, add yourself to the above list. This is not
 just for legal reasons, but also to keep an overview of all those nicknames.

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -75,7 +75,12 @@ file = fmap catMaybes (many line)
 readConfigMap :: SourceName -> IO (Either ParseError StringMap)
 readConfigMap name = do
   result <- parseFromFile file name
-  return (fmap (Map.fromList . reverse) result)
+  return (fmap resultToStringMap result)
+
+-- result is an association list [(String, String)]
+-- if a key appears twice in the list it overwrites the previous result
+-- therefore we have to reverse the list to prefer the first association
+resultToStringMap result = Map.fromList (reverse result)
 
 readConfig :: FilePath -> IO Config
 readConfig path =

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -41,25 +41,19 @@ identifier = do
 
 -- comment parser
 comment :: Parser ()
-comment = do
-  _ <- char '#'
-  skipMany (noneOf "\n")
-  <?> "comment"
+comment = char '#' >> skipMany (noneOf "\n") <?> "comment"
 
 
 -- end of line parser
 eol :: Parser ()
-eol = do
-  _ <- oneOf "\n"
-  return ()
-  <?> "end of line"
+eol = oneOf "\n" >> return () <?> "end of line"
 
 -- single line parser
 item :: Parser (String, String)
 item = do
   key <- identifier     -- config entry key
   skipMany space
-  _ <- char '='         -- aand assign a value to that key
+  char '='         -- aand assign a value to that key
   skipMany space
   value <- manyTill anyChar (try eol <|> try comment <|> eof)
   return (key, rstrip value)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -40,7 +40,10 @@ identifier = do
 
 -- comment parser
 comment :: Parser ()
-comment = char '#' >> void (anyCharTill eol) <?> "comment"
+comment = do
+    char '#'
+    void (anyCharTill eol)
+    <?> "comment"
 
 -- any character till an end character
 anyCharTill = manyTill anyChar
@@ -64,8 +67,8 @@ item = do
 -- line parser, is nothing if line is a comment only
 line :: Parser (Maybe (String, String))
 line = do
-  skipMany space
-  try (Nothing <$ comment) <|> (Just <$> item)
+    skipMany space
+    try (Nothing <$ comment) <|> (Just <$> item)
 
 -- file parser, contains many lines
 -- drops all comments lines
@@ -87,11 +90,11 @@ readConfig path =
   do
     cmap <- readConfigMap path
     case cmap of
-     Left err -> error ("config parsing failed: " ++ (show err))
+     Left err -> error ("config parsing failed: " ++ show err)
      Right m  -> do
        let cfg = createConfig m
        case cfg of
         Nothing -> error "config file has missing keys"
         Just c -> do
-          putStrLn ("configuration:\n" ++ (show c))
+          putStrLn ("configuration:\n" ++ show c)
           return c

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -41,7 +41,7 @@ identifier = do
 -- comment parser
 comment :: Parser ()
 comment = do
-    char '#'
+    _ <- char '#'
     void (anyCharTill eol)
     <?> "comment"
 
@@ -57,7 +57,7 @@ item :: Parser (String, String)
 item = do
   key <- identifier     -- config entry key
   skipMany space
-  char '='         -- aand assign a value to that key
+  _ <- char '='         -- aand assign a value to that key
   skipMany space
   value <- anyCharTill (try eol <|> try comment <|> eof)
   return (key, rstrip value)

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -9,7 +9,6 @@ import Text.ParserCombinators.Parsec
 
 import qualified Data.Map as Map
 
-
 -- the config file has these entries
 data Config = Config {
   netPort    :: Int,
@@ -29,7 +28,6 @@ createConfig m = do
   dbpass <- Map.lookup "db_password" m
   Just (Config (read port) dbhost dbname dbuser dbpass)
 
-
 type StringMap = Map.Map String String
 
 -- config key parser
@@ -42,8 +40,10 @@ identifier = do
 
 -- comment parser
 comment :: Parser ()
-comment = void (char '#' >> manyTill anyChar eol) <?> "comment"
+comment = char '#' >> void (anyCharTill eol) <?> "comment"
 
+-- any character till an end character
+anyCharTill = manyTill anyChar
 
 -- end of line parser
 eol :: Parser ()
@@ -56,7 +56,7 @@ item = do
   skipMany space
   char '='         -- aand assign a value to that key
   skipMany space
-  value <- manyTill anyChar (try eol <|> try comment <|> eof)
+  value <- anyCharTill (try eol <|> try comment <|> eof)
   return (key, rstrip value)
   where rstrip = reverse . dropWhile isSpace . reverse
 

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -2,7 +2,7 @@
 
 module Config where
 
-import Control.Monad
+import Control.Monad(void)
 import Data.Char
 import Data.Maybe
 import Text.ParserCombinators.Parsec
@@ -18,7 +18,7 @@ data Config = Config {
   dbPassword :: String
 } deriving (Show)
 
--- convert the string -> string map to our wanted config
+-- convert the string => string map to our wanted config
 createConfig :: StringMap -> Maybe Config
 createConfig m = do
   port <- Map.lookup "port" m
@@ -45,7 +45,7 @@ comment = do
     void (anyCharTill eol)
     <?> "comment"
 
--- any character till an end character
+-- any character till an end parser
 anyCharTill = manyTill anyChar
 
 -- end of line parser


### PR DESCRIPTION
Improved config parser's readability
- used `void action` instead of `action >> return ()`
- removed quirks like `_ <- action`
- used fmap and its alias `<$>` when it improved readability
- moved out some functions and added comments
