### PR TITLE
Add command line Arguments

### DIFF
--- a/etc/openage/masterserver.yaml
+++ b/etc/openage/masterserver.yaml
@@ -2,9 +2,9 @@
 # version 1.0.0
 acceptedVersion: [1,0,0]
 # Port server is running on
-port: 1234
+serverPort: 1234
 # Database connection information
-database:
+postgresConf:
   host: localhost
   database: masterserver
   password: test1

--- a/openage-masterserver.cabal
+++ b/openage-masterserver.cabal
@@ -23,6 +23,7 @@ library
   ghc-options:         -O2 -Wall -dynamic -threaded -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   hs-source-dirs:      src
   exposed-modules:     Masterserver.Protocol
+                     , Masterserver.Args
                      , Masterserver.Config
                      , Masterserver.Database
                      , Masterserver.Server

--- a/openage-masterserver.cabal
+++ b/openage-masterserver.cabal
@@ -56,10 +56,12 @@ executable openage-masterserver
                      , bytestring >= 0.10
                      , containers >= 0.5
                      , network >= 2.6
+                     , mtl
                      , persistent
                      , stm >= 2.4
                      , text
                      , openage-masterserver
+                     , yaml >= 0.8
   default-language:    Haskell2010
 
 executable openage-masterserver-test

--- a/openage-masterserver.cabal
+++ b/openage-masterserver.cabal
@@ -20,7 +20,7 @@ extra-source-files:  README.md
 cabal-version:       >=1.10
 
 library
-  ghc-options:         -O2 -Wall -Werror -dynamic -threaded -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  ghc-options:         -O2 -Wall -dynamic -threaded -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   hs-source-dirs:      src
   exposed-modules:     Masterserver.Protocol
                      , Masterserver.Config
@@ -46,7 +46,7 @@ library
   default-language:    Haskell2010
 
 executable openage-masterserver
-  ghc-options:         -O2 -Wall -Werror -dynamic -threaded -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  ghc-options:         -O2 -Wall -dynamic -threaded -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   hs-source-dirs:      src/main/
   main-is:             Main.hs
   build-depends:       base >=4.7
@@ -65,7 +65,7 @@ executable openage-masterserver
 executable openage-masterserver-test
   hs-source-dirs:      test/
   main-is:             TestCli.hs
-  ghc-options:         -O2 -Wall -Werror -dynamic -threaded -rtsopts -with-rtsopts=-N -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
+  ghc-options:         -O2 -Wall -dynamic -threaded -rtsopts -with-rtsopts=-N -fwarn-tabs -fwarn-incomplete-uni-patterns -fwarn-incomplete-record-updates
   build-depends:       base
                      , openage-masterserver
                      , async >= 2.1

--- a/src/Masterserver/Args.hs
+++ b/src/Masterserver/Args.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-----------------------------------------------------------------------------
+-- |
+-- Copyright 2016-2016 the openage authors. See copying.md for legal info.
+-- Module: Masterserver.Config
+--
+-- This Module defines the masterservers commandline argument parser.
+
+-----------------------------------------------------------------------------
+module Masterserver.Args where
+
+import System.Console.GetOpt
+import System.Environment
+import System.Exit
+import System.IO as S
+
+data Options = Options  { optConfPath :: FilePath}
+
+startOptions :: Options
+startOptions = Options  { optConfPath = "etc/openage/masterserver.yaml"
+                        }
+
+options :: [ OptDescr (Options -> IO Options) ]
+options =
+     [ Option "c" ["config"]
+        (ReqArg
+            (\arg opt -> return opt { optConfPath = arg })
+            "FILE")
+        "Config path"
+    , Option "h" ["help"]
+        (NoArg
+            (\_ -> do
+                prg <- getProgName
+                S.hPutStrLn stderr (usageInfo prg options)
+                exitSuccess))
+        "Show help"
+    ]
+

--- a/src/Masterserver/Args.hs
+++ b/src/Masterserver/Args.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -15,25 +16,59 @@ import System.Environment
 import System.Exit
 import System.IO as S
 
-data Options = Options  { optConfPath :: FilePath}
+import Masterserver.Config
 
-startOptions :: Options
-startOptions = Options  { optConfPath = "etc/openage/masterserver.yaml"
-                        }
+data Options = Options
+  { optConfPath :: FilePath
+  , optPort :: Maybe Int
+  }
+
+defaultOptions :: Options
+defaultOptions = Options
+  { optConfPath = "etc/openage/masterserver.yaml"
+  , optPort = Nothing
+  }
+
+header :: String
+header = "Usage: openage-masterserver [options]...\nOptions:\n"
 
 options :: [ OptDescr (Options -> IO Options) ]
 options =
-     [ Option "c" ["config"]
-        (ReqArg
-            (\arg opt -> return opt { optConfPath = arg })
-            "FILE")
-        "Config path"
-    , Option "h" ["help"]
-        (NoArg
-            (\_ -> do
-                prg <- getProgName
-                S.hPutStrLn stderr (usageInfo prg options)
-                exitSuccess))
-        "Show help"
-    ]
+  [ Option "h" ["help"]   (NoArg printHelp)
+    "Print help"
+  , Option "c" ["config"] (ReqArg readConfPath "FILE")
+    "config file to use"
+  , Option "p" ["port"]   (ReqArg readPort "NUM")
+    "port to use"
+  ]
 
+printHelp :: Options -> IO Options
+printHelp _ = do
+  S.hPutStrLn stderr (usageInfo header options)
+  exitSuccess
+
+readPort :: String -> Options -> IO Options
+readPort arg opt = return opt { optPort = Just (read arg) }
+
+readConfPath :: String -> Options -> IO Options
+readConfPath arg opt = return opt { optConfPath = arg }
+
+parseOpts :: IO Config
+parseOpts = do
+  args <- getArgs
+  case getOpt RequireOrder options args of
+    (actions, [], [])
+      -> do
+      opts <- foldl (>>=) (return defaultOptions) actions
+      buildConfig opts
+    (_, nonOpts, [])
+      -> error $ "unrecognized arguments: " ++ unwords nonOpts
+    (_, _, msgs)
+      -> error $ concat msgs ++ usageInfo header options
+
+-- | Reads config file from config path specified in args and returns a config
+-- with specified options or, if not given, options read from file
+buildConfig :: Options -> IO Config
+buildConfig Options{..} = do
+  conf <- loadConf optConfPath
+  maybe (return conf) (\p -> return (conf {serverPort=p})) optPort

--- a/src/Masterserver/Args.hs
+++ b/src/Masterserver/Args.hs
@@ -4,7 +4,7 @@
 -----------------------------------------------------------------------------
 -- |
 -- Copyright 2016-2016 the openage authors. See copying.md for legal info.
--- Module: Masterserver.Config
+-- Module: Masterserver.Args
 --
 -- This Module defines the masterservers commandline argument parser.
 

--- a/src/Masterserver/Protocol.hs
+++ b/src/Masterserver/Protocol.hs
@@ -111,7 +111,7 @@ type GameName = Text
 newGame :: GameName -> AuthPlayerName -> Text -> Int -> STM Game
 newGame gameName gameHost gameMap numPlayers =
   return Game { gamePlayers=Map.empty
-              , gameMode="Deathmatch", ..}
+              , gameMode="None", ..}
 
 -- | Game participant, players ingame settings
 data Participant = Participant
@@ -122,7 +122,7 @@ data Participant = Participant
   } deriving Show
 
 newParticipant :: AuthPlayerName -> Bool -> Participant
-newParticipant parName parReady = Participant{ parCiv="Britain"
+newParticipant parName parReady = Participant{ parCiv="None"
                                              , parTeam=0, ..}
 
 Prelude.concat <$> mapM (deriveJSON defaultOptions) [''InMessage,

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 -----------------------------------------------------------------------------
 -- |
@@ -17,8 +18,10 @@ module Main where
 import Control.Concurrent
 import Control.Concurrent.STM
 import Control.Concurrent.Async
+import System.Console.GetOpt
 import Control.Exception.Base (finally)
 import Control.Monad
+import Control.Monad.Reader
 import Crypto.BCrypt
 import Data.Aeson
 import Data.ByteString as B
@@ -30,88 +33,130 @@ import Data.Maybe
 import Data.Text as T
 import Data.Version (makeVersion)
 import Database.Persist
+import Data.Yaml (decodeFile)
 import Network
 import Text.Printf
 import System.IO as S
+import System.Environment
+import System.Exit
 
 import Masterserver.Config
 import Masterserver.Database
 import Masterserver.Protocol as P
 import Masterserver.Server
 
+data Options = Options  { optConfPath :: FilePath}
+
+startOptions :: Options
+startOptions = Options  { optConfPath = "etc/openage/masterserver.yaml"
+                        }
+
 main :: IO ()
 main = withSocketsDo $ do
-  port <- getPort
+  args <- getArgs
+  -- Parse options, getting a list of option actions
+  let (actions, nonOptions, errors) = getOpt RequireOrder options args
+  -- Here we thread startOptions through all supplied option actions
+  opts <- L.foldl (>>=) (return startOptions) actions
+  let Options { optConfPath = path} = opts
+  conf <- loadConf path
+  let port = serverPort conf
   server <- newServer
   sock <- listenOn (PortNumber (fromIntegral port))
   printf "Listening on port %d\n" port
   forever $ do
       (handle, host, clientPort) <- accept sock
       printf "Accepted connection from %s: %s\n" host (show clientPort)
-      forkFinally (talk handle server host) (\_ ->
+      forkFinally (runReaderT (talk handle server host) conf) (\_ ->
         printf "Connection from %s closed\n" host >> hClose handle)
 
-talk :: Handle -> Server -> HostName -> IO()
+options :: [ OptDescr (Options -> IO Options) ]
+options =
+     [ Option "c" ["config"]
+        (ReqArg
+            (\arg opt -> return opt { optConfPath = arg })
+            "FILE")
+        "Input string"
+    , Option "h" ["help"]
+        (NoArg
+            (\_ -> do
+                prg <- getProgName
+                S.hPutStrLn stderr (usageInfo prg options)
+                exitSuccess))
+        "Show help"
+    ]
+
+talk :: (MonadReader Config m, MonadIO m)
+     => Handle
+     -> Server
+     -> HostName
+     -> m ()
 talk handle server hostname = do
-  S.hSetNewlineMode handle universalNewlineMode
-  S.hSetBuffering handle LineBuffering
+  liftIO $ S.hSetNewlineMode handle universalNewlineMode
+  liftIO $ S.hSetBuffering handle LineBuffering
   checkVersion handle
   mayClient <- checkAddClient handle server hostname
   case mayClient of
-    Just client@Client{..} -> do
+    Just client@Client{..} -> liftIO $ do
       sendMessage handle "Login success."
       runClient server client
         `finally` removeClientLeave server clientName
     Nothing ->
-      sendError handle "Login failed."
+      liftIO $ sendError handle "Login failed."
 
--- | Compare Version to own
-checkVersion :: S.Handle -> IO ()
+-- | Compare Version to the one speciefied in the environment.
+checkVersion :: (MonadReader Config m, MonadIO m)
+             => S.Handle
+             -> m ()
 checkVersion handle = do
-  verJson <- B.hGetLine handle
-  myVersion <- getVersion
+  verJson <- liftIO $ B.hGetLine handle
+  myVersion <- asks acceptedVersion
   if ( peerProtocolVersion
      . fromJust
      . decode
      . BL.fromStrict) verJson == makeVersion myVersion
     then
-      sendMessage handle "Version accepted."
-    else do
+      liftIO $ sendMessage handle "Version accepted."
+    else liftIO $ do
       sendError handle "Incompatible Version."
       thread <- myThreadId
       killThread thread
 
 -- | Get login credentials from handle, add client to servers
 -- clientmap and return Client
-checkAddClient :: Handle -> Server -> HostName -> IO(Maybe Client)
+checkAddClient :: (MonadReader Config m, MonadIO m)
+               => Handle
+               -> Server
+               -> HostName
+               -> m (Maybe Client)
 checkAddClient handle server@Server{..} hostname = do
-  loginJson <- B.hGetLine handle
+  loginJson <- liftIO $ B.hGetLine handle
   case (decode . BL.fromStrict) loginJson of
     Just Login{..} -> do
       let toBs = BC.pack . T.unpack
       Just (Entity _ Player{..}) <- getPlayer loginName
       if validatePassword playerPassword (toBs loginPassword)
         then do
-          clientMap <- readTVarIO clients
-          client <- newClient playerUsername hostname handle
+          clientMap <- liftIO $ readTVarIO clients
+          client <- liftIO $ newClient playerUsername hostname handle
           if member playerUsername clientMap
             then do
-              sendChannel (clientMap!playerUsername) Logout
-              atomically $ addClient server client
+              liftIO $ sendChannel (clientMap!playerUsername) Logout
+              liftIO $ atomically $ addClient server client
               return $ Just client
             else do
-              atomically $ addClient server client
+              liftIO $ atomically $ addClient server client
               return $ Just client
         else return Nothing
     Just AddPlayer{..} -> do
-      hash <- hashPw pw
+      hash <- liftIO $ hashPw pw
       res <- addPlayer name hash
-      maybe (sendError handle "Name taken."
+      maybe (liftIO (sendError handle "Name taken.")
              >> checkAddClient handle server hostname)
-        (\_ -> sendMessage handle "Player successfully added."
+        (\_ -> liftIO (sendMessage handle "Player successfully added.")
                >> checkAddClient handle server hostname) res
     _ -> do
-      sendError handle "Unknown Format."
+      liftIO $ sendError handle "Unknown Format."
       return Nothing
 
 -- | Uses BCrypt to hash pw before writing it to db

--- a/src/main/Main.hs
+++ b/src/main/Main.hs
@@ -34,8 +34,6 @@ import Data.Version (makeVersion)
 import Database.Persist
 import Network
 import Text.Printf
-import System.Console.GetOpt
-import System.Environment
 import System.IO as S
 
 import Masterserver.Config
@@ -46,13 +44,7 @@ import Masterserver.Args
 
 main :: IO ()
 main = withSocketsDo $ do
-  args <- getArgs
-  -- Parse options, getting a list of option actions
-  let (actions, _, _) = getOpt RequireOrder options args
-  -- Here we thread startOptions through all supplied option actions
-  opts <- L.foldl (>>=) (return startOptions) actions
-  let Options { optConfPath = path} = opts
-  conf <- loadConf path
+  conf <- parseOpts
   let port = serverPort conf
   server <- newServer
   sock <- listenOn (PortNumber (fromIntegral port))

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,13 +2,13 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.1
+resolver: lts-5.9
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps: [aeson-0.11.0.0]
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
### Reader Monad

To be able to overwrite config settings with command line arguments i had to rethink the way we access the config file.
In the new solution i removed the now unnecessary getter functions like `getPort :: IO Int`
and instead made the Config globally accessible by using the monad transformer ReaderT and keeping the config in the [Reader Monad](https://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Reader.html).
Therefore all functions needing config acces now have a type signature of:

``` haskell
(MonadReader Config m, MonadIO m) => a -> m (a)
```

The config itself can now be loaded with Readers `ask` function.
Single config records can be accessed via asks as in `myVersion <- asks acceptedVersion`
### Command line arguments

Command line arguments are parsed in a new File calles Args.hs.
it provides a function named `parseOpts` which if successful returns a Config object as loaded from the config file, where specially specified records like port are overwritten with the command line arguments.
Usage info can be printed with `-h` or `--help` and looks like this:

```
Usage: openage-masterserver [options]...
Options:

  -h       --help         Print help
  -c FILE  --config=FILE  config file to use
  -p NUM   --port=NUM     port to use

```
